### PR TITLE
feat: add baseUrl to Replicate constructor

### DIFF
--- a/src/Replicate.php
+++ b/src/Replicate.php
@@ -13,13 +13,14 @@ final class Replicate extends Connector
 {
     public function __construct(
         public string $apiToken,
+        public string $baseUrl = 'https://api.replicate.com/v1'
     ) {
         $this->withTokenAuth($this->apiToken, 'Token');
     }
 
     public function resolveBaseUrl(): string
     {
-        return 'https://api.replicate.com/v1';
+        return $this->baseUrl;
     }
 
     protected function defaultHeaders(): array


### PR DESCRIPTION
This PR adds baseUrl as an argument to the constructor of Replicate class.

Makes it easy to use this package with cog containers running on local or non-replicate servers.
